### PR TITLE
relative URL metatag image

### DIFF
--- a/src/components/Metatags.tsx
+++ b/src/components/Metatags.tsx
@@ -11,7 +11,7 @@ interface MetatagsProps {
 const Metatags: React.FC<MetatagsProps> = ({
   title = 'wavey baby blogs',
   description = 'unfortunately, i am about to get sexier',
-  image = 'https://github.com/darreltrinh/nextfire-app/blob/usernameform-bug-fix-loader/public/the_big_man.jpeg',
+  image = '/the_big_man.jpeg',
 }) => {
   return (
     <Head>


### PR DESCRIPTION
relative URL

Yes, it will work even if your MetaTags component is in the src/components folder and the JPEG file is in the public folder. The reason is that the public folder in a Next.js project is designed to serve static assets like images, and these assets can be accessed using a relative URL.

When you use a relative URL that starts with a forward slash (like /the_big_man.jpeg), it references the root of your public folder, regardless of where your component is located within the project structure. So, when you use /the_big_man.jpeg, it will point to the the_big_man.jpeg file in your public folder.